### PR TITLE
replace 1.52 with 4.8 in episode 4.4.1 on algebraic calculation

### DIFF
--- a/Jupyter_Book/SHDS/04.e. Population.and.samples.ipynb
+++ b/Jupyter_Book/SHDS/04.e. Population.and.samples.ipynb
@@ -55,7 +55,7 @@
     "It is then  easy to calculate the expectation and variance of $\\hat{\\mu}$ using techniques covered in the maths refresher. So we know that the sampling distribution of $\\hat{\\mu}$ is:\n",
     "\n",
     "$$\n",
-    "\\hat{\\mu} \\sim N\\left(\\mu, 1.52^2 \\right) \n",
+    "\\hat{\\mu} \\sim N\\left(\\mu, 4.8^2 \\right) \n",
     "$$\n",
     "\n",
     "where the variance of this normal distribution was obtained as\n",
@@ -68,7 +68,7 @@
     "This gives us a lot of useful information about how the sampling distribution in relation to the unknown parameter $\\mu$: \n",
     "- It follows a normal distribution (has a symmetric bell-shape)\n",
     "- It is centred around the true (unknown) population value\n",
-    "- The standard error of the sample mean (the standard deviation of the estimator) is  $1.52$.\n",
+    "- The standard error of the sample mean (the standard deviation of the estimator) is  $4.8$.\n",
     "\n",
     "In many situations, this sort of algebraic calculation is possible. If not, we often rely on the central limit theorem to obtain the approximate sampling distribution in large samples.\n"
    ]


### PR DESCRIPTION
In episode [4.4.1 on Algebraic calculation](https://lshtm-hds.github.io/Content-2021/04.e.%20Population.and.samples.html#algebraic-calculation) which is in [file 04.e](https://github.com/LSHTM-HDS/Content-2021/blob/main/Jupyter_Book/SHDS/04.e.%20Population.and.samples.ipynb), we have that:

> the true value of the population standard deviation,  σ=4.8

However, in [line 58 of the raw document](https://github.com/LSHTM-HDS/Content-2021/blob/a26f188d452ab3c65252eac1996e8d6dcd5c8c4e/Jupyter_Book/SHDS/04.e.%20Population.and.samples.ipynb#L58C38-L58C42) it says: 

> the sampling distribution of μ^ is: μ^∼N(μ,1.52^2)

And in [line 71](https://github.com/LSHTM-HDS/Content-2021/blob/a26f188d452ab3c65252eac1996e8d6dcd5c8c4e/Jupyter_Book/SHDS/04.e.%20Population.and.samples.ipynb#L71) is also says:

> The standard error of the sample mean (the standard deviation of the estimator) is 1.52.

Should we replace the number `1.52` in these two lines with `4.8`?